### PR TITLE
doctest wip

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,19 @@ preserves the monoidal structure.
 
 This library encodes monoidal functors and related structures in
 Haskell.
+
+## Testing
+
+Using Doctest to find all Haskell sources:
+
+```sh
+cabal exec -- cabal test
+```
+
+or individual files:
+
+```sh
+cabal exec -- doctest -isrc -XLambdaCase -XUndecidableInstances -XFunctionalDependencies src/Control/Category/Cartesian.hs
+```
+
+TODO: Find out how to enable extensions automatically.

--- a/monoidal-functors.cabal
+++ b/monoidal-functors.cabal
@@ -86,7 +86,7 @@ library
   hs-source-dirs: src
 
   default-language: Haskell2010
-  
+
 --------------------------------------------------------------------------------
 
 executable co-log
@@ -99,3 +99,11 @@ executable co-log
                    , distributive
                    , monoidal-functors
                    , mtl
+
+test-suite monoidal-functors-test
+  import:            common-extensions
+  type:              exitcode-stdio-1.0
+  main-is:           Main.hs
+  hs-source-dirs:    src, test
+  build-depends:     doctest
+

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,0 +1,39 @@
+module Main where
+
+import Prelude
+import Test.DocTest ( doctest )
+import System.Process
+
+main :: IO ()
+main = do
+  let cmd = shell "find src -name '*.hs'"
+  hsString <- readCreateProcess cmd ""
+  let sources = lines hsString
+  print sources
+  doctest
+    $ "-isrc"
+    : "-XConstraintKinds"
+    : "-XDeriveFunctor"
+    : "-XDerivingVia"
+    : "-XFunctionalDependencies"
+    : "-XFlexibleInstances"
+    : "-XFlexibleContexts"
+    : "-XGeneralizedNewtypeDeriving"
+    : "-XImportQualifiedPost"
+    : "-XInstanceSigs"
+    : "-XKindSignatures"
+    : "-XLambdaCase"
+    : "-XMultiParamTypeClasses"
+    : "-XNoImplicitPrelude"
+    : "-XQuantifiedConstraints"
+    : "-XRankNTypes"
+    : "-XScopedTypeVariables"
+    : "-XStandaloneDeriving"
+    : "-XTupleSections"
+    : "-XTypeApplications"
+    : "-XTypeOperators"
+    : "-XUndecidableInstances"
+    : "-XDataKinds"
+    : sources
+
+


### PR DESCRIPTION
Some examples do work:

```
> cabal exec -- doctest -isrc -XLambdaCase -XUndecidableInstances -XFunctionalDependencies src/Control/Category/Cartesian.hs
Warning: ignoring unrecognised input `.'
Examples: 25  Tried: 25  Errors: 0  Failures: 0
```

However, currently running into this bug:

```
> cabal exec -- cabal test
Build profile: -w ghc-9.2.5 -O1
In order, the following will be built (use -v for more details):
 - monoidal-functors-0.2.1.0 (test:monoidal-functors-test) (first run)
Preprocessing test suite 'monoidal-functors-test' for monoidal-functors-0.2.1.0..
Building test suite 'monoidal-functors-test' for monoidal-functors-0.2.1.0..
Loaded package environment from /Users/lyndon/code/monoidal-functors/dist-newstyle/tmp/environment.-18821/.ghc.environment.x86_64-darwin-9.2.5
Loaded package environment from /Users/lyndon/code/monoidal-functors/dist-newstyle/tmp/environment.-18821/.ghc.environment.x86_64-darwin-9.2.5
Running 1 test suites...
Test suite monoidal-functors-test: RUNNING...
Warning: ignoring unrecognised input `.'

src/Data/Bifunctor/BiInvariant.hs:110:65: error:ghc-9.2.5: panic! (the 'impossible' happened)
  (GHC version 9.2.5:
	No skolem info:
  [k1_a9lA]
  Call stack:
      CallStack (from HasCallStack):
        callStackDoc, called at compiler/GHC/Utils/Panic.hs:181:37 in ghc:GHC.Utils.Panic
        pprPanic, called at compiler/GHC/Tc/Errors.hs:2912:17 in ghc:GHC.Tc.Errors

Please report this as a GHC bug:  https://www.haskell.org/ghc/reportabug
```