### PR TITLE
Add Kleisli and Star instances for relevant Cartesian instances

### DIFF
--- a/src/Control/Category/Cartesian.hs
+++ b/src/Control/Category/Cartesian.hs
@@ -17,9 +17,11 @@ where
 
 --------------------------------------------------------------------------------
 
+import Control.Arrow (Kleisli (..))
 import Control.Category (id, (>>>))
 import Control.Category.Tensor (Iso (..), Symmetric, Tensor (..), (#))
 import Data.Functor.Contravariant (Op (..))
+import Data.Profunctor (Star (..))
 import Data.Void (Void, absurd)
 import Prelude hiding (fst, id, snd)
 
@@ -75,6 +77,14 @@ instance (Semicocartesian (->) t) => Semicartesian Op t where
   split :: (Semicocartesian (->) t) => Op a (t a a)
   split = Op merge
 
+instance (Monad m) => Semicartesian (Star m) (,) where
+  split :: Star m a (a, a)
+  split = Star $ \x -> pure (x, x)
+
+instance (Monad m) => Semicartesian (Kleisli m) (,) where
+  split :: Kleisli m a (a, a)
+  split = Kleisli $ \x -> pure (x, x)
+
 --------------------------------------------------------------------------------
 
 -- | A 'Category' is 'Semicocartesian' if it is equipped with a
@@ -121,6 +131,14 @@ instance Semicocartesian (->) Either where
 instance (Semicartesian (->) t) => Semicocartesian Op t where
   merge :: (Semicartesian (->) t) => Op (t a a) a
   merge = Op split
+
+instance (Monad m) => Semicocartesian (Star m) Either where
+  merge :: Star m (Either a a) a
+  merge = Star $ either pure pure
+
+instance (Monad m) => Semicocartesian (Kleisli m) Either where
+  merge :: Kleisli m (Either a a) a
+  merge = Kleisli $ either pure pure
 
 --------------------------------------------------------------------------------
 
@@ -177,6 +195,14 @@ instance (Cocartesian (->) t i) => Cartesian Op t i where
   kill :: (Cocartesian (->) t i) => Op a i
   kill = Op spawn
 
+instance (Monad m) => Cartesian (Star m) (,) () where
+  kill :: Star m a ()
+  kill = Star $ \_ -> pure ()
+
+instance (Monad m) => Cartesian (Kleisli m) (,) () where
+  kill :: Kleisli m a ()
+  kill = Kleisli $ \_ -> pure ()
+
 --------------------------------------------------------------------------------
 
 -- | A 'Category' equipped with a 'Tensor' @t@ where the 'Tensor' unit @i@ is the <https://ncatlab.org/nlab/show/initial+object initial object>
@@ -221,3 +247,11 @@ instance (Cartesian (->) t i) => Cocartesian Op t i where
 instance Cocartesian (->) Either Void where
   spawn :: Void -> a
   spawn = absurd
+
+instance (Monad m) => Cocartesian (Star m) Either Void where
+  spawn :: Star m Void a
+  spawn = Star (\void -> pure $ absurd void)
+
+instance (Monad m) => Cocartesian (Kleisli m) Either Void where
+  spawn :: Kleisli m Void a
+  spawn = Kleisli (\void -> pure $ absurd void)

--- a/src/Control/Category/Tensor.hs
+++ b/src/Control/Category/Tensor.hs
@@ -108,21 +108,47 @@ instance (GBifunctor (->) (->) (->) t) => GBifunctor Op Op Op t where
 instance (Bifunctor t) => GBifunctor (->) (->) (->) t where
   gbimap = bimap
 
-instance GBifunctor (Star Maybe) (Star Maybe) (Star Maybe) These where
-  gbimap :: Star Maybe a b -> Star Maybe c d -> Star Maybe (These a c) (These b d)
+instance (Monad m) => GBifunctor (Star m) (Star m) (Star m) These where
+  gbimap :: Star m a b -> Star m c d -> Star m (These a c) (These b d)
   gbimap (Star f) (Star g) =
     Star $ \case
       This a -> This <$> f a
       That c -> That <$> g c
       These a c -> liftA2 These (f a) (g c)
 
-instance GBifunctor (Kleisli Maybe) (Kleisli Maybe) (Kleisli Maybe) These where
-  gbimap :: Kleisli Maybe a b -> Kleisli Maybe c d -> Kleisli Maybe (These a c) (These b d)
+instance (Monad m) => GBifunctor (Kleisli m) (Kleisli m) (Kleisli m) These where
+  gbimap :: Kleisli m a b -> Kleisli m c d -> Kleisli m (These a c) (These b d)
   gbimap (Kleisli f) (Kleisli g) =
     Kleisli $ \case
       This a -> This <$> f a
       That c -> That <$> g c
       These a c -> liftA2 These (f a) (g c)
+
+instance (Monad m) => GBifunctor (Star m) (Star m) (Star m) (,) where
+  gbimap :: Star m a b -> Star m c d -> Star m (a, c) (b, d)
+  gbimap (Star f) (Star g) =
+    Star $ \(a, c) ->
+      liftA2 (,) (f a) (g c)
+
+instance (Monad m) => GBifunctor (Kleisli m) (Kleisli m) (Kleisli m) (,) where
+  gbimap :: Kleisli m a b -> Kleisli m c d -> Kleisli m (a, c) (b, d)
+  gbimap (Kleisli f) (Kleisli g) =
+    Kleisli $ \(a, c) ->
+      liftA2 (,) (f a) (g c)
+
+instance (Monad m) => GBifunctor (Star m) (Star m) (Star m) Either where
+  gbimap :: Star m a b -> Star m c d -> Star m (Either a c) (Either b d)
+  gbimap (Star f) (Star g) =
+    Star $ \case
+      Left a -> Left <$> f a
+      Right c -> Right <$> g c
+
+instance (Monad m) => GBifunctor (Kleisli m) (Kleisli m) (Kleisli m) Either where
+  gbimap :: Kleisli m a b -> Kleisli m c d -> Kleisli m (Either a c) (Either b d)
+  gbimap (Kleisli f) (Kleisli g) =
+    Kleisli $ \case
+      Left a -> Left <$> f a
+      Right c -> Right <$> g c
 
 instance (GBifunctor cat cat cat t) => GBifunctor (Iso cat) (Iso cat) (Iso cat) t where
   gbimap :: Iso cat a b -> Iso cat c d -> Iso cat (t a c) (t b d)


### PR DESCRIPTION
Adds Cartesian instances for Kleisli and Star

Note that this generalizes the `GBifunctor` instances from `Maybe` to any `Monad m => m`, which seems correct to me, but is worth double-checking :) 